### PR TITLE
merge: 중복 저장 문제 해결

### DIFF
--- a/src/main/java/com/example/kummiRoom_backend/api/entity/Course.java
+++ b/src/main/java/com/example/kummiRoom_backend/api/entity/Course.java
@@ -15,7 +15,12 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@Table(name = "course")
+@Table(
+        name = "course",
+        uniqueConstraints = @UniqueConstraint(
+                columnNames = {"school_id", "course_name", "semester"}
+        )
+)
 public class Course {
 
     @Id

--- a/src/main/java/com/example/kummiRoom_backend/api/entity/School.java
+++ b/src/main/java/com/example/kummiRoom_backend/api/entity/School.java
@@ -1,4 +1,5 @@
 package com.example.kummiRoom_backend.api.entity;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/example/kummiRoom_backend/openApi/OpenApiService.java
+++ b/src/main/java/com/example/kummiRoom_backend/openApi/OpenApiService.java
@@ -144,7 +144,6 @@ public class OpenApiService {
             System.out.println("[DEBUG] JSON 응답: " + rowArray);
 
             if (rowArray.isArray()) {
-                //저장 함수
                 return saveSchoolsFromApi(rowArray);
             }
 

--- a/src/main/java/com/example/kummiRoom_backend/openApi/OpenApiService.java
+++ b/src/main/java/com/example/kummiRoom_backend/openApi/OpenApiService.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -39,8 +40,16 @@ public class OpenApiService {
 
 
     public List<Course> getCourseFromTimeTable(NeisTimetableRequestDto req) throws Exception {
+        Set<String> existingCourseKeys = new HashSet<>();
         Set<String> courseNameSet = new HashSet<>();
         List<Course> courseList = new ArrayList<>();
+
+        // 기존 Course를 한 번에 조회해서 중복 확인용 set 만들기
+        List<Course> existingCourses = courseRepository.findAllBySchool_SchoolId(req.getSdSchulCode());
+        for (Course course : existingCourses) {
+            String key = course.getCourseName() + "_" + course.getSemester();
+            existingCourseKeys.add(key);
+        }
 
         for (int i = 1; i <= 2; i++) { // pindex 1과 2 두 번 반복
             String url = UriComponentsBuilder.fromHttpUrl(testBaseUrl)
@@ -75,10 +84,14 @@ public class OpenApiService {
                 if (rowArray.isArray()) {
                     for (JsonNode node : rowArray) {
                         String courseName = node.path("ITRT_CNTNT").asText();
-                        String grade = node.path("GRADE").asText(); // 학년 정보
+                        String grade = node.path("GRADE").asText();
+                        String semester = node.path("GRADE").asText() + "학년 " + node.path("SEM").asText() + "학기";
+                        Long schoolId = node.path("SD_SCHUL_CODE").asLong();
 
                         String courseKey = courseName + "_" + grade;
 
+                        String key = courseName + "_" + semester;
+                        if (existingCourseKeys.contains(key)) continue; // 중복 → 스킵
                         if (courseNameSet.contains(courseKey)) continue;
                         courseNameSet.add(courseKey);
                         System.out.println(courseNameSet);
@@ -89,11 +102,10 @@ public class OpenApiService {
                                 .courseType("공통")
                                 .courseArea(node.path("ORD_SC_NM").asText()) // 예: 일반계
                                 .semester(node.path("GRADE").asText() + "학년 " + node.path("SEM").asText() + "학기") // 예: 1학년 1학기
-                                .description(node.path("DGHT_CRSE_SC_NM").asText() + " " + node.path("GRADE").asText() + "학년") // 예: 주간 1학년
+                                .description(node.path("DGHT_CRSE_SC_NM").asText())
                                 .updatedAt(LocalDateTime.now())
                                 .maxStudents(0) // 임의 초기값
                                 .build();
-                        System.out.println(course);
                         courseList.add(course);
                     }
                 }
@@ -101,7 +113,6 @@ public class OpenApiService {
                 throw new RuntimeException("NEIS API 호출 실패");
             }
         }
-
         return courseRepository.saveAll(courseList);
     }
 
@@ -172,7 +183,6 @@ public class OpenApiService {
                 schoolEntities.add(school);
             }
         }
-        System.out.println("[DEBUG] saveSchoolsFromApi: " + schoolEntities);
 
         return schoolRepository.saveAll(schoolEntities);
     }

--- a/src/main/java/com/example/kummiRoom_backend/openApi/dto/requestDto/NeisTimetableRequestDto.java
+++ b/src/main/java/com/example/kummiRoom_backend/openApi/dto/requestDto/NeisTimetableRequestDto.java
@@ -13,7 +13,7 @@ public class NeisTimetableRequestDto {
     @JsonProperty("ATPT_OFCDC_SC_CODE")
     private String atptOfcdcScCode;
     @JsonProperty("SD_SCHUL_CODE")
-    private String sdSchulCode;
+    private Long sdSchulCode;
 //    private String grade;
 //    private String classNm;
 //    private String ay;


### PR DESCRIPTION
개요
- NEIS 시간표 API를 통해 가져온 수업 데이터를 DB에 저장할 때,
- 중복 Course가 계속 저장되는 문제가 있어 이를 해결했습니다.

---

문제 원인
- 기존에는 API 재호출 시 동일한 수업 정보가 중복 저장되며,
- DB에 유니크 제약 조건이 없어 중복 데이터가 삽입되거나
- 유니크 제약을 걸 경우 `DataIntegrityViolationException`이 빈번하게 발생했습니다.

---

해결 방법
- `schoolId + courseName + semester` 기준으로 DB에서 기존 Course 목록을 미리 조회
- 메모리(Set)를 사용하여 중복 여부를 판단
- 신규 수업만 `saveAll()`로 일괄 저장하여 DB 쿼리 횟수를 줄이고, 예외 발생도 최소화