### PR TITLE
refactor: 로그아웃 시 쿠키 삭제 및 Redis refreshToken 제거

### DIFF
--- a/src/main/java/com/example/kummiRoom_backend/global/auth/AuthService.java
+++ b/src/main/java/com/example/kummiRoom_backend/global/auth/AuthService.java
@@ -50,11 +50,7 @@ public class AuthService {
             throw new UnauthorizedException("아이디/이메일 또는 비밀번호를 잘못 입력하셨습니다.");
         }
 
-        userRepository.save(user);
-        return AuthResponseDto.builder()
-                .accessToken(jwtService.generateAccessToken(user.getAuthId(), user.getUserId()))
-                .refreshToken(jwtService.generateRefreshToken(user.getAuthId(), user.getUserId()))
-                .build();
+        return generateTokens(user.getAuthId(), user.getUserName(), user.getUserId());
     }
 
     public void register(RegisterRequestDto request) {


### PR DESCRIPTION
# Auth 리팩토링

## redis 에 저장 안되는 문제

<img width="824" alt="스크린샷 2025-05-19 오후 3 32 11" src="https://github.com/user-attachments/assets/46a4c21b-6401-4712-baf5-aee4be088738" />

generateTokens  메소드 안에는 redis 를 저장하는 로직이 있는데

<img width="709" alt="스크린샷 2025-05-20 오후 7 34 43" src="https://github.com/user-attachments/assets/f3bfa350-cc8f-4d32-80df-65b9a33e9bfd" />

login 에 보면 generateTokens 를 부르는게 아니라 jwtService 에 있는 generateAccessToken 이랑 generateRefreshToken 을 불러옴

## 로그아웃 개선

<img width="814" alt="스크린샷 2025-05-20 오후 1 51 22" src="https://github.com/user-attachments/assets/a9c439b8-273f-4241-b3e8-ade87ebb0ae3" />


로그아웃 시 accessToken 에서 authId 빼와서 redis 에 authId 기준으로 저장되어 있는 refreshToken 삭제

```
        accessTokenCookie.setMaxAge(60);
        refreshTokenCookie.setMaxAge(60);
        accessTokenCookie.setMaxAge(0)
        refreshTokenCookie.setMaxAge(0);
```
로그아웃 시 쿠키가 바로 삭제 되도록 변경