### PR TITLE
fix: 사용자 프로필 업데이트에 이미지 추가

### DIFF
--- a/src/main/java/com/example/kummiRoom_backend/api/dto/requestDto/UpdateProfileRequestDto.java
+++ b/src/main/java/com/example/kummiRoom_backend/api/dto/requestDto/UpdateProfileRequestDto.java
@@ -12,4 +12,5 @@ public class UpdateProfileRequestDto {
     private String phone;
     private String userName;
     private LocalDate birth;
+    private String imageUrl;
 }

--- a/src/main/java/com/example/kummiRoom_backend/api/dto/responseDto/UserProfileResponseDto.java
+++ b/src/main/java/com/example/kummiRoom_backend/api/dto/responseDto/UserProfileResponseDto.java
@@ -21,4 +21,5 @@ public class UserProfileResponseDto {
     private Integer grade;
     private Integer classNum;
     private SchoolDto school;
+    private String imageUrl;
 }

--- a/src/main/java/com/example/kummiRoom_backend/api/entity/User.java
+++ b/src/main/java/com/example/kummiRoom_backend/api/entity/User.java
@@ -35,6 +35,9 @@ public class User {
     private String phone;
     private LocalDate birth;
 
+    @Column(nullable = true)
+    private String imageUrl;
+
     @OneToMany(mappedBy = "user")
     @JsonIgnore
     private List<TimeTable> timeTables;

--- a/src/main/java/com/example/kummiRoom_backend/api/service/UserService.java
+++ b/src/main/java/com/example/kummiRoom_backend/api/service/UserService.java
@@ -42,6 +42,7 @@ public class UserService {
                 .birth(user.getBirth())
                 .phone(user.getPhone())
                 .address(user.getAddress())
+                .imageUrl(user.getImageUrl())
                 .interestMajor(majorDto)  // 여기서 안전하게 null 또는 값 세팅
                 .grade(user.getGrade())
                 .classNum(user.getClassNum())
@@ -74,6 +75,10 @@ public class UserService {
         user.setPhone(request.getPhone());
         user.setUserName(request.getUserName());
         user.setBirth(request.getBirth());
+
+        if(request.getImageUrl() != null) {
+            user.setImageUrl(request.getImageUrl());
+        }
 
         userRepository.save(user);
     }


### PR DESCRIPTION
## 사용자 프로필 업데이트에 이미지 추가

- s3를 사용해서 이미지 url 을 사용자 정보 db 에 저장해야합니다.
- 프론트에서 직접 s3 에 이미지를 저장하고 url 을 post api/users/me 를 통해 보내주도록 되어있습니다.

```json
if (request.getImageUrl() != null) {
    user.setImageUrl(request.getImageUrl());
}
```

→ 이렇게 처리한 이유는 request 에서 imageUrl 이 null 이면 사용자가 이미지 수정을 안하겠다는 의미일 수 있는데 이런 조건 없이 setImageUrl(null) 하면 기존에 저장되어있던 이미지 url 이 지워져버리 수 있기 때문입니다.