### PR TITLE
fix: 사용자 정보 가져오기 imageUrl 누락

### DIFF
--- a/src/main/java/com/example/kummiRoom_backend/api/dto/responseDto/UserProfileResponseDto.java
+++ b/src/main/java/com/example/kummiRoom_backend/api/dto/responseDto/UserProfileResponseDto.java
@@ -17,9 +17,9 @@ public class UserProfileResponseDto {
     private LocalDate birth;
     private String phone;
     private String address;
+    private String imageUrl;
     private MajorDto interestMajor;
     private Integer grade;
     private Integer classNum;
     private SchoolDto school;
-    private String imageUrl;
 }


### PR DESCRIPTION
- ~~기존 UserProfileResponseDto 에서 imageUrl 이 Dto 하단에 선언되어 json 에서 누락됐습니다.~~
- imageUrl 의 순서가 맞지 않아 제일 하단에 나타나고 있었습니다.
- imageUrl 을 상단으로 이동시켜 수정했습니다.