### PR TITLE
feature: 사용자 비밀번호 변경

### DIFF
--- a/src/main/java/com/example/kummiRoom_backend/api/controller/UserController.java
+++ b/src/main/java/com/example/kummiRoom_backend/api/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.kummiRoom_backend.api.controller;
 
 import com.example.kummiRoom_backend.api.dto.requestDto.AddMajorRequestDto;
+import com.example.kummiRoom_backend.api.dto.requestDto.ChangePasswordRequestDto;
 import com.example.kummiRoom_backend.api.dto.requestDto.UpdateProfileRequestDto;
 import com.example.kummiRoom_backend.api.dto.requestDto.UpdateSchoolInfoRequestDto;
 import com.example.kummiRoom_backend.api.service.UserService;
@@ -11,6 +12,7 @@ import com.example.kummiRoom_backend.global.exception.UnauthorizedException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -69,4 +71,18 @@ public class UserController {
 
         return ResponseEntity.ok(new ApiResult(200, "OK", "학교 정보가 성공적으로 수정되었습니다."));
     }
+
+    @PostMapping("/password")
+    public ResponseEntity<?> changePassword(@RequestBody ChangePasswordRequestDto request, HttpServletRequest httpRequest) {
+        String accessToken = authService.getCookieValue(httpRequest, "accessToken");
+        if (accessToken == null) {
+            throw new UnauthorizedException("액세스 토큰이 없습니다");
+        }
+
+        Long userId = jwtService.extractUserId(accessToken);
+        userService.changePassword(userId, request);
+
+        return ResponseEntity.ok(new ApiResult(200, "OK", "비밀번호가 성공적으로 변경되었습니다."));
+    }
+
 }

--- a/src/main/java/com/example/kummiRoom_backend/api/dto/requestDto/ChangePasswordRequestDto.java
+++ b/src/main/java/com/example/kummiRoom_backend/api/dto/requestDto/ChangePasswordRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.kummiRoom_backend.api.dto.requestDto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChangePasswordRequestDto {
+	private String currentPassword;
+	private String newPassword;
+}


### PR DESCRIPTION
## 사용자 비밀번호 변경
- 사용자가 현재 비밀번호와 새 비밀번호를 입력해 비밀 번호를 변경할 수 있는 기능입니다.
- 현재 비밀번호가 db 에 저장된 암호화된 비밀번호와 일치하는지 확인 -> 새 비밀번호가 6자 이상 13자 이하 인지 확인
- 암호화된 새 비밀번호를 db 에 저장합니다.

- 현재 비밀번호와 일치하지 않을 때, 새 비밀번호 가 6자 이상 13자 이하가 아닐 때, 사용자 정보가 없을때 예외처리했습니다.

추가로 AuthService 에 register 에서 비밀번호 제한조건이 프론트에서 구현한 비밀번호 제한조건과 안맞는것 같습니다.
일단 비밀번호 변경은 AuthService 기준으로 작성하긴했는데 추후에 맞춰봐야 할 것 같습니다.